### PR TITLE
[Feature] Maven file encoding warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,10 @@
         <sonar.login>f3e43ff4f0692fcd97fc41da1a7f890c79a86b5b</sonar.login>
         <sonar.organization>boyshawn-github</sonar.organization>
         <maven.developmentVersion>0-SNAPSHOT</maven.developmentVersion>
+        <!--Prevent "File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!"
+        This warning is emitted by a plugin that processes plain text files but has not been configured to use a
+        specific file encoding.-->
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <scm>


### PR DESCRIPTION
Add source encoding to the project to resolve the warning emitted during build.