### PR TITLE
[Bugfix] String index out of bounds exception in parsing MasterCard transaction

### DIFF
--- a/src/main/java/expense_tally/csv_parser/model/MasterCard.java
+++ b/src/main/java/expense_tally/csv_parser/model/MasterCard.java
@@ -1,5 +1,8 @@
 package expense_tally.csv_parser.model;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.time.LocalDate;
 import java.time.Month;
 import java.time.format.DateTimeFormatter;
@@ -14,6 +17,7 @@ import java.util.StringJoiner;
  * @see CsvTransaction
  */
 public class MasterCard extends CsvTransaction {
+    private static final Logger LOGGER = LogManager.getLogger(MasterCard.class);
     //TODO: Change to custom format
     private String cardNumber;
 
@@ -57,7 +61,13 @@ public class MasterCard extends CsvTransaction {
     public static LocalDate extractTransactionDate(LocalDate bankTransactionDate, String reference1) {
         final String RAW_DATE_FORMAT = "yyyyddMMM";
         int yearOfTransaction = bankTransactionDate.getYear();
-        String monthOfTransactionString = convertToTitleCase(extractLastWord(reference1).substring(2, 5));
+        if (reference1.isBlank()) {
+            LOGGER.warn("reference1 is empty");
+            return bankTransactionDate;
+        }
+        String lastWord = extractLastWord(reference1);
+        String month = lastWord.substring(2 , 5);
+        String monthOfTransactionString = convertToTitleCase(month);
         if ("Dec".equals(monthOfTransactionString) && bankTransactionDate.getMonth() == Month.JANUARY) {
             yearOfTransaction--;
         }


### PR DESCRIPTION
Exception in thread "main" java.lang.StringIndexOutOfBoundsException: begin 2, end 5, length 0
	at java.base/java.lang.String.checkBoundsBeginEnd(String.java:3720)
	at java.base/java.lang.String.substring(String.java:1909)
	at expense_tally.csv_parser.model.MasterCard.extractTransactionDate(MasterCard.java:60)
	at expense_tally.csv_parser.CsvParser.parseSingleTransaction(CsvParser.java:144)
	at expense_tally.csv_parser.CsvParser.parseCsvFile(CsvParser.java:68)
	at expense_tally.ExpenseAccountant.getCsvTransactionsFrom(ExpenseAccountant.java:101)
	at expense_tally.ExpenseAccountant.reconcileData(ExpenseAccountant.java:84)
	at expense_tally.Main.main(Main.java:24)