### PR TITLE
SonarQube bugfix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
       name: "Static code analysis"
       script:
         - git fetch --unshallow --no-tags origin +refs/heads/master:refs/remotes/origin/master
-        - mvn sonar:sonar
+        - mvn org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar
     - stage: release
       name: "Only for master: Prepare deliveries for release"
       # require the branch name to be master (note for PRs this is the base branch name)


### PR DESCRIPTION
Found a bug in the SonarQubue whereby the current master branch doesn't upload the correct code coverage. Fix by manually use Jacoco to prepare the report then upload to SonarCloud