### PR TITLE
Dependency Upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,28 +32,28 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.12.1</version>
+            <version>2.13.0</version>
         </dependency>
         <!-- This is needed for Yaml logging -->
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.10.0.pr3</version>
+            <version>2.10.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.0.pr3</version>
+            <version>2.10.1</version>
         </dependency>
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.28.0</version>
+            <version>3.30.1</version>
         </dependency>
         <dependency>
             <groupId>org.junit-pioneer</groupId>
             <artifactId>junit-pioneer</artifactId>
-            <version>0.3.0</version>
+            <version>0.4.2</version>
             <scope>test</scope>
         </dependency>
         <!-- junit-platform-launcher and junit-jupiter-engine are needed by Maven so that surefire can run the test case.
@@ -61,62 +61,62 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>1.5.2</version>
+            <version>1.6.0-M1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.5.2</version>
+            <version>5.6.0-M1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.5.2</version>
+            <version>5.6.0-M1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.1.0</version>
+            <version>3.2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>3.1.0</version>
+            <version>3.2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.13.2</version>
+            <version>3.14.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <scope>compile</scope>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-base</artifactId>
-            <version>13</version>
+            <version>14-ea+6</version>
         </dependency>
         <dependency>
             <scope>compile</scope>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
-            <version>13</version>
+            <version>14-ea+6</version>
         </dependency>
         <dependency>
             <scope>compile</scope>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
-            <version>13</version>
+            <version>14-ea+6</version>
         </dependency>
         <dependency>
             <scope>compile</scope>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-graphics</artifactId>
-            <version>13</version>
+            <version>14-ea+6</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Upgrade to log4j-core 2.13.0
Upgrade to jackson-dataformat-yaml 2.10.1
Upgrade to jackson-databind 2.10.1
Upgrade to sqlite-jdbc 3.30.1
Upgrade to junit-pioneer 0.4.2
Upgrade to junit-platform-launcher 1.6.0-M1
Upgrade to junit-jupiter-engine 5.6.0-M1
Upgrade to junit-jupiter-api 5.6.0-M1
Upgrade to mockito-core 3.2.4
Upgrade to mockito-junit-jupiter 3.2.4
Upgrade to assertj-core 3.14.0
Upgrade to javafx-base 14-ea+6
Upgrade to javafx-controls 14-ea+6
Upgrade to javafx-fxml 14-ea+6
Upgrade to javafx-graphics 14-ea+6