### PR TITLE
Final class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,12 @@
             <version>3.3.3</version>
             <scope>test</scope>
         </dependency>
+        <!-- This allows us to mock final class-->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>3.3.3</version>
+        </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>

--- a/src/main/java/expense_tally/csv_parser/CsvParser.java
+++ b/src/main/java/expense_tally/csv_parser/CsvParser.java
@@ -38,7 +38,7 @@ import static expense_tally.csv_parser.CsvPosition.TRANSACTION_REF_3;
  *
  * @see CsvTransaction
  */
-public class CsvParser implements CsvParsable {
+public final class CsvParser implements CsvParsable {
   private static final Logger LOGGER = LogManager.getLogger(CsvParser.class);
   private static final String CSV_HEADER_LINE = "Transaction Date";
   private static final String CSV_TRANSACTION_DATE_FORMAT = "dd MMM yyyy"; //09 Nov 2018

--- a/src/main/java/expense_tally/csv_parser/InvalidReferenceDateException.java
+++ b/src/main/java/expense_tally/csv_parser/InvalidReferenceDateException.java
@@ -1,6 +1,6 @@
 package expense_tally.csv_parser;
 
-public class InvalidReferenceDateException extends Exception {
+public final class InvalidReferenceDateException extends Exception {
   private static final long serialVersionUID = 10763608L;
 
   public InvalidReferenceDateException(String message) {

--- a/src/main/java/expense_tally/csv_parser/MasterCard.java
+++ b/src/main/java/expense_tally/csv_parser/MasterCard.java
@@ -17,7 +17,7 @@ import java.util.StringJoiner;
  *
  * @see CsvTransaction
  */
-public class MasterCard extends CsvTransaction {
+public final class MasterCard extends CsvTransaction {
   private static final Logger LOGGER = LogManager.getLogger(MasterCard.class);
   private static final char SPACE_CHARACTER = ' ';
   private static final DateTimeFormatter REFERENCE_1_DATE_FORMAT = DateTimeFormatter.ofPattern("ddMMM");

--- a/src/main/java/expense_tally/csv_parser/MonetaryAmountException.java
+++ b/src/main/java/expense_tally/csv_parser/MonetaryAmountException.java
@@ -1,6 +1,6 @@
 package expense_tally.csv_parser;
 
-public class MonetaryAmountException extends Exception {
+public final class MonetaryAmountException extends Exception {
   public MonetaryAmountException(String message) {
     super(message);
   }

--- a/src/main/java/expense_tally/expense_manager/persistence/ExpenseReport.java
+++ b/src/main/java/expense_tally/expense_manager/persistence/ExpenseReport.java
@@ -6,7 +6,7 @@ import java.util.Objects;
  * This class models the database schema of a transaction stored in the Expense Manager application. All the
  * attributes inside this class model after the equivalence data type of the database schema declaration.
  */
-public class ExpenseReport {
+public final class ExpenseReport {
   private int id;
   private String account;
   private String amount;

--- a/src/main/java/expense_tally/expense_manager/persistence/ExpenseReportReader.java
+++ b/src/main/java/expense_tally/expense_manager/persistence/ExpenseReportReader.java
@@ -18,7 +18,7 @@ import java.util.Objects;
  *
  * @see ExpenseReport
  */
-public class ExpenseReportReader implements ExpenseReadable {
+public final class ExpenseReportReader implements ExpenseReadable {
   private static final Logger LOGGER = LogManager.getLogger(ExpenseReportReader.class);
 
   private DatabaseConnectable databaseConnectable;

--- a/src/main/java/expense_tally/expense_manager/persistence/SqlLiteConnection.java
+++ b/src/main/java/expense_tally/expense_manager/persistence/SqlLiteConnection.java
@@ -12,7 +12,7 @@ import java.util.Objects;
  * , SQLite library is linked and form part of the application. Hence there isn't a database server. The entire
  * database (definitions, tables, indices, and the data itself) is stored inside a single cross-platform file.</p>
  */
-public class SqlLiteConnection implements DatabaseConnectable {
+public final class SqlLiteConnection implements DatabaseConnectable {
   private static final String SQLITE_JDBC_PREFIX = "jdbc:sqlite:";
   private final String databaseFile;
 

--- a/src/main/java/expense_tally/expense_manager/transformation/ExpenseManagerTransaction.java
+++ b/src/main/java/expense_tally/expense_manager/transformation/ExpenseManagerTransaction.java
@@ -7,7 +7,7 @@ import java.util.StringJoiner;
 /**
  *
  */
-public class ExpenseManagerTransaction {
+public final class ExpenseManagerTransaction {
   private Double amount;
   private ExpenseCategory category;
   private ExpenseSubCategory subcategory;

--- a/src/main/java/expense_tally/expense_manager/transformation/ExpenseTransactionMapper.java
+++ b/src/main/java/expense_tally/expense_manager/transformation/ExpenseTransactionMapper.java
@@ -25,7 +25,7 @@ import java.util.Map;
  * @see ExpenseManagerTransaction
  * @see ExpenseReport
  */
-public class ExpenseTransactionMapper {
+public final class ExpenseTransactionMapper {
   private static final Logger LOGGER = LogManager.getLogger(ExpenseTransactionMapper.class);
 
   private static final String REFERENCE_AMOUNT_NUMBER_FORMAT = "[^\\d\\.]+";

--- a/src/main/java/expense_tally/reconciliation/DiscrepantTransaction.java
+++ b/src/main/java/expense_tally/reconciliation/DiscrepantTransaction.java
@@ -11,7 +11,7 @@ import java.util.StringJoiner;
 /**
  * Display a transaction which has discrepancy among the data sources.
  */
-public class DiscrepantTransaction {
+public final class DiscrepantTransaction {
   private static final Logger LOGGER = LogManager.getLogger(DiscrepantTransaction.class);
 
   private LocalDate time;

--- a/src/main/java/expense_tally/reconciliation/ExpenseReconciler.java
+++ b/src/main/java/expense_tally/reconciliation/ExpenseReconciler.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * Reconciles the expenses between the Expense Manager application and the CSV file.
  */
-public class ExpenseReconciler {
+public final class ExpenseReconciler {
   private static final Logger LOGGER = LogManager.getLogger(ExpenseReconciler.class);
   private static final int MAXIMUM_TIME_DIFFERENCE_ALLOWED = 24;
   private static final String NULL_CSV_TRANSACTION_EXCEPTION_MSG = "Null reference is not an accepted csvTransactions value.";

--- a/src/main/java/expense_tally/views/cli/CommandLineRunner.java
+++ b/src/main/java/expense_tally/views/cli/CommandLineRunner.java
@@ -20,7 +20,7 @@ import java.util.Map;
  * This class acts as the Dependency Injection container. It create all the dependencies and inject into the rest of
  * the class
  */
-public class CommandLineRunner {
+public final class CommandLineRunner {
   private static final Logger LOGGER = LogManager.getLogger(CommandLineRunner.class);
 
   public static void main(String[] args) {

--- a/src/main/java/expense_tally/views/cli/CommandParser.java
+++ b/src/main/java/expense_tally/views/cli/CommandParser.java
@@ -7,7 +7,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.EnumMap;
 import java.util.Map;
 
-public class CommandParser {
+public final class CommandParser {
   private static final Logger LOGGER = LogManager.getLogger(CommandParser.class);
 
   public CommandParser() { //Default implementation

--- a/src/main/java/expense_tally/views/cli/ExpenseAccountant.java
+++ b/src/main/java/expense_tally/views/cli/ExpenseAccountant.java
@@ -23,7 +23,7 @@ import java.util.Objects;
  * <p>The word Accountant is used as that is the job of the accountant in the real finance department.</p>
  * <p>This marks the start of the whole program.</p>
  */
-public class ExpenseAccountant {
+public final class ExpenseAccountant {
   private static final Logger LOGGER = LogManager.getLogger(ExpenseAccountant.class);
   private final CsvParsable csvParsable;
   private final ExpenseReadable expenseReadable;

--- a/src/main/java/expense_tally/views/desktop/DesktopClient.java
+++ b/src/main/java/expense_tally/views/desktop/DesktopClient.java
@@ -10,7 +10,7 @@ import java.net.URL;
 
 //ADD THIS IN THE VM option before running
 //--module-path "C:\Program Files\Java\javafx-sdk-13.0.1\lib" --add-modules=javafx.controls,javafx.fxml
-public class DesktopClient extends Application {
+public final class DesktopClient extends Application {
   private static final String TITLE = "Expense Tally";
   private static final String FXML_RELATIVE_PATH = "/ui/ui.fxml";
 

--- a/src/main/java/expense_tally/views/desktop/controllers/MainController.java
+++ b/src/main/java/expense_tally/views/desktop/controllers/MainController.java
@@ -42,7 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
 
-public class MainController implements Initializable {
+public final class MainController implements Initializable {
   @FXML
   TableColumn<Transaction, Boolean> tableAddRecordCheckBox;
   @FXML

--- a/src/main/java/expense_tally/views/desktop/model/Transaction.java
+++ b/src/main/java/expense_tally/views/desktop/model/Transaction.java
@@ -5,7 +5,7 @@ import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleStringProperty;
 
-public class Transaction {
+public final class Transaction {
   private SimpleBooleanProperty meantToBeAddedToDatabase;
   private SimpleStringProperty time;
   private SimpleDoubleProperty amount;


### PR DESCRIPTION
As per the good practice from Effective Java, we can prevent finalizer attacks by declaring our class that is not meant to have sub-class final. For Mockito to work, an additional dependency on mockito-inline is used.