### PR TITLE
Version update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,22 +38,22 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.11.0</version>
+            <version>2.11.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.11.0</version>
+            <version>2.11.2</version>
         </dependency>
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.31.1</version>
+            <version>3.32.3.2</version>
         </dependency>
         <dependency>
             <groupId>org.junit-pioneer</groupId>
             <artifactId>junit-pioneer</artifactId>
-            <version>0.6.0</version>
+            <version>0.9.0</version>
             <scope>test</scope>
         </dependency>
         <!-- junit-platform-launcher and junit-jupiter-engine are needed by Maven so that surefire can run the test case.
@@ -61,43 +61,43 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>1.7.0-M1</version>
+            <version>1.7.0-RC1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.7.0-M1</version>
+            <version>5.7.0-RC1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.7.0-M1</version>
+            <version>5.7.0-RC1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.3.3</version>
+            <version>3.5.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>3.3.3</version>
+            <version>3.5.7</version>
             <scope>test</scope>
         </dependency>
         <!-- This allows us to mock final class-->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>3.3.3</version>
+            <version>3.5.7</version>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.16.1</version>
+            <version>3.17.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
jackson-dataformat-yaml 2.11.0 to 2.11.2
jackson-databind 2.11.0 to 2.11.2
sqlite-jdbc 3.31.1 to 3.32.3.2
junit-pioneer 0.6.0 to 0.9.0
junit-platform-launcher 1.7.0-M1 to 1.7.0-RC1
junit-jupiter-engine 5.7.0-M1 to 5.7.0-RC1
junit-jupiter-api 5.7.0-M1 to 5.7.0-RC1
mockito-core 3.3.3 to 3.5.7
mockito-junit-jupiter 3.3.3 to 3.5.7
mockito-inline 3.3.3 to 3.5.7
assertj-core 3.16.1 to 3.17.1