### PR TITLE
Enrich models and provider adapters to capture full API data

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A serverless expense tracking application with automatic bank transaction syncin
 - **Frontend**: React 18, TypeScript, Vite, Tailwind CSS
 - **Auth**: Amazon Cognito (email + OAuth)
 - **Infrastructure**: AWS SAM (CloudFormation)
-- **Bank Integration**: Teller API
+- **Bank Integration**: SimpleFIN Bridge, Teller API
 
 ## Project Structure
 
@@ -26,7 +26,7 @@ expense-tally/
 │       ├── model/         # Domain models
 │       ├── repository/    # DynamoDB data access
 │       ├── service/       # Business logic
-│       └── provider/      # Bank API adapters (Teller)
+│       └── provider/      # Bank API adapters (SimpleFIN, Teller)
 └── frontend/
     └── src/
         ├── pages/         # Dashboard, Transactions, Categories, ReviewQueue, ManualEntry, Login
@@ -40,7 +40,7 @@ expense-tally/
 - **Dashboard** - Spending aggregations by category, month, and payment method
 - **Transaction Management** - View, edit, and confirm synced transactions
 - **Category Management** - Organize transactions with categories and keyword-based auto-suggestions
-- **Bank Sync** - Automatic transaction syncing via Teller API (daily scheduled + manual trigger)
+- **Bank Sync** - Automatic transaction syncing via SimpleFIN Bridge and Teller API (daily scheduled + manual trigger)
 - **Review Queue** - Review and confirm unconfirmed transactions
 - **Manual Entry** - Add transactions manually
 
@@ -112,6 +112,7 @@ Comprehensive documentation is available in the [`docs/`](docs/) directory:
 | [Developer Guide](docs/DEVELOPER-GUIDE.md) | Setup, coding conventions, Git workflow, development patterns |
 | [Deployment](docs/DEPLOYMENT.md) | CI/CD pipelines, SAM infrastructure, deployment procedures |
 | [API Reference](docs/API.md) | Full API endpoint reference with request/response examples |
+| [ADR-001](docs/adr/001-enrich-api-data-capture.md) | Enrich database to capture full provider API data |
 
 ## API Endpoints
 

--- a/backend/internal/model/models.go
+++ b/backend/internal/model/models.go
@@ -10,6 +10,14 @@ type Transaction struct {
 	Currency            string  `json:"currency"`
 	Description         string  `json:"description"`
 	Merchant            string  `json:"merchant"`
+	Payee               string  `json:"payee,omitempty"`
+	Memo                string  `json:"memo,omitempty"`
+	TransactionType     string  `json:"transactionType,omitempty"`
+	ProviderCategory    string  `json:"providerCategory,omitempty"`
+	CounterpartyType    string  `json:"counterpartyType,omitempty"`
+	RunningBalance      *string `json:"runningBalance,omitempty"`
+	InstitutionName     string  `json:"institutionName,omitempty"`
+	InstitutionID       string  `json:"institutionId,omitempty"`
 	CategoryID          *string `json:"categoryId,omitempty"`
 	SuggestedCategoryID *string `json:"suggestedCategoryId,omitempty"`
 	IsConfirmed         bool    `json:"isConfirmed"`
@@ -41,11 +49,22 @@ type KeywordAssociation struct {
 
 // ProviderConnection represents a bank connection.
 type ProviderConnection struct {
-	PK             string  `json:"id"`
-	Provider       string  `json:"provider"`
-	AccessTokenRef string  `json:"accessTokenRef"`
-	SyncCursor     string  `json:"syncCursor,omitempty"`
-	LastSyncedAt   *string `json:"lastSyncedAt,omitempty"`
+	PK               string  `json:"id"`
+	Provider         string  `json:"provider"`
+	AccessTokenRef   string  `json:"accessTokenRef"`
+	SyncCursor       string  `json:"syncCursor,omitempty"`
+	LastSyncedAt     *string `json:"lastSyncedAt,omitempty"`
+	AccountName      string  `json:"accountName,omitempty"`
+	AccountType      string  `json:"accountType,omitempty"`
+	AccountSubtype   string  `json:"accountSubtype,omitempty"`
+	InstitutionName  string  `json:"institutionName,omitempty"`
+	InstitutionID    string  `json:"institutionId,omitempty"`
+	Currency         string  `json:"currency,omitempty"`
+	LastFour         string  `json:"lastFour,omitempty"`
+	Balance          *string `json:"balance,omitempty"`
+	AvailableBalance *string `json:"availableBalance,omitempty"`
+	BalanceUpdatedAt *string `json:"balanceUpdatedAt,omitempty"`
+	Status           string  `json:"status,omitempty"`
 }
 
 // SyncLog represents a sync run log.
@@ -120,8 +139,28 @@ type SimpleFINSetupRequest struct {
 
 // SimpleFINAccount represents an account from SimpleFIN Bridge.
 type SimpleFINAccount struct {
+	ID               string  `json:"id"`
+	Name             string  `json:"name"`
+	Currency         string  `json:"currency"`
+	InstitutionName  string  `json:"institutionName"`
+	Balance          *string `json:"balance,omitempty"`
+	AvailableBalance *string `json:"availableBalance,omitempty"`
+	BalanceDate      *string `json:"balanceDate,omitempty"`
+	OrgDomain        string  `json:"orgDomain,omitempty"`
+	OrgURL           string  `json:"orgUrl,omitempty"`
+	OrgID            string  `json:"orgId,omitempty"`
+}
+
+// TellerAccount represents an account from Teller API.
+type TellerAccount struct {
 	ID              string `json:"id"`
+	EnrollmentID    string `json:"enrollment_id"`
 	Name            string `json:"name"`
+	Type            string `json:"type"`
+	Subtype         string `json:"subtype"`
+	Status          string `json:"status"`
 	Currency        string `json:"currency"`
-	InstitutionName string `json:"institutionName"`
+	LastFour        string `json:"last_four"`
+	InstitutionID   string `json:"institution_id,omitempty"`
+	InstitutionName string `json:"institution_name,omitempty"`
 }

--- a/backend/internal/provider/simplefin.go
+++ b/backend/internal/provider/simplefin.go
@@ -35,20 +35,23 @@ type simpleFINAccountSet struct {
 
 // simpleFINAccount represents an account in the SimpleFIN response.
 type simpleFINAccount struct {
-	Org          simpleFINOrg          `json:"org"`
-	ID           string                `json:"id"`
-	Name         string                `json:"name"`
-	Currency     string                `json:"currency"`
-	Balance      string                `json:"balance"`
-	BalanceDate  int64                 `json:"balance-date"`
-	Transactions []simpleFINTransaction `json:"transactions"`
+	Org              simpleFINOrg          `json:"org"`
+	ID               string                `json:"id"`
+	Name             string                `json:"name"`
+	Currency         string                `json:"currency"`
+	Balance          string                `json:"balance"`
+	AvailableBalance string                `json:"available-balance"`
+	BalanceDate      int64                 `json:"balance-date"`
+	Transactions     []simpleFINTransaction `json:"transactions"`
 }
 
 // simpleFINOrg represents the organization (institution) in SimpleFIN.
 type simpleFINOrg struct {
 	Domain  string `json:"domain"`
 	SfinURL string `json:"sfin-url"`
+	URL     string `json:"url"`
 	Name    string `json:"name"`
+	ID      string `json:"id"`
 }
 
 // simpleFINTransaction represents a transaction in the SimpleFIN response.
@@ -57,6 +60,8 @@ type simpleFINTransaction struct {
 	Posted       int64           `json:"posted"`
 	Amount       string          `json:"amount"`
 	Description  string          `json:"description"`
+	Payee        string          `json:"payee"`
+	Memo         string          `json:"memo"`
 	Pending      bool            `json:"pending"`
 	TransactedAt int64           `json:"transacted_at"`
 	Extra        json.RawMessage `json:"extra,omitempty"`
@@ -109,12 +114,28 @@ func (s *SimpleFINAdapter) ListAccounts(ctx context.Context, accessURL string) (
 		if orgName == "" {
 			orgName = acct.Org.Domain
 		}
-		accounts = append(accounts, model.SimpleFINAccount{
+		sa := model.SimpleFINAccount{
 			ID:              acct.ID,
 			Name:            acct.Name,
 			Currency:        acct.Currency,
 			InstitutionName: orgName,
-		})
+			OrgDomain:       acct.Org.Domain,
+			OrgURL:          acct.Org.URL,
+			OrgID:           acct.Org.ID,
+		}
+		if acct.Balance != "" {
+			bal := acct.Balance
+			sa.Balance = &bal
+		}
+		if acct.AvailableBalance != "" {
+			avail := acct.AvailableBalance
+			sa.AvailableBalance = &avail
+		}
+		if acct.BalanceDate > 0 {
+			bd := time.Unix(acct.BalanceDate, 0).UTC().Format(time.RFC3339)
+			sa.BalanceDate = &bd
+		}
+		accounts = append(accounts, sa)
 	}
 	return accounts, nil
 }
@@ -158,36 +179,44 @@ func (s *SimpleFINAdapter) FetchTransactions(ctx context.Context, accessToken st
 			date := posted.Format("2006-01-02")
 			year := posted.Format("2006")
 
-			// Format transacted_at if present (non-zero)
 			var transactedAt string
 			if st.TransactedAt != 0 {
 				transactedAt = time.Unix(st.TransactedAt, 0).UTC().Format("2006-01-02")
 			}
 
-			// Serialize the full SimpleFIN transaction JSON as raw payload
 			rawPayload, _ := json.Marshal(st)
+
+			// Use payee as merchant when available; fall back to institution name.
+			merchant := st.Payee
+			if merchant == "" {
+				merchant = orgName
+			}
 
 			pk := "TXN#simplefin#" + acct.ID + "#" + st.ID
 
 			txn := model.Transaction{
-				PK:            pk,
-				Date:          date,
-				TransactedAt:  transactedAt,
-				Source:        "simplefin",
-				Amount:        amount,
-				Currency:      acct.Currency,
-				Description:   st.Description,
-				Merchant:      orgName,
-				IsConfirmed:   false,
-				Pending:       st.Pending,
-				PaymentMethod: "card",
-				AccountID:     acct.ID,
-				AccountName:   acct.Name,
-				RawPayload:    string(rawPayload),
-				CreatedAt:     now,
-				UpdatedAt:     now,
-				GSI1PK:        "YEAR#" + year,
-				GSI2PK:        "UNCONFIRMED",
+				PK:              pk,
+				Date:            date,
+				TransactedAt:    transactedAt,
+				Source:          "simplefin",
+				Amount:          amount,
+				Currency:        acct.Currency,
+				Description:     st.Description,
+				Merchant:        merchant,
+				Payee:           st.Payee,
+				Memo:            st.Memo,
+				InstitutionName: orgName,
+				InstitutionID:   acct.Org.ID,
+				IsConfirmed:     false,
+				Pending:         st.Pending,
+				PaymentMethod:   "card",
+				AccountID:       acct.ID,
+				AccountName:     acct.Name,
+				RawPayload:      string(rawPayload),
+				CreatedAt:       now,
+				UpdatedAt:       now,
+				GSI1PK:          "YEAR#" + year,
+				GSI2PK:          "UNCONFIRMED",
 			}
 			txns = append(txns, txn)
 

--- a/backend/internal/provider/teller.go
+++ b/backend/internal/provider/teller.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -29,14 +30,37 @@ func NewTellerAdapter(certFile, keyFile string) *TellerAdapter {
 
 // TellerTransaction represents a transaction from Teller API.
 type TellerTransaction struct {
-	ID          string  `json:"id"`
-	Amount      float64 `json:"amount"`
-	Currency    string  `json:"currency"`
-	Description string  `json:"description"`
-	Date        string  `json:"date"`
-	Details     *struct {
+	ID             string  `json:"id"`
+	AccountID      string  `json:"account_id"`
+	Amount         string  `json:"amount"`
+	Currency       string  `json:"currency"`
+	Description    string  `json:"description"`
+	Date           string  `json:"date"`
+	Status         string  `json:"status"`
+	Type           string  `json:"type"`
+	RunningBalance *string `json:"running_balance"`
+	Details        *struct {
 		CounterpartyName string `json:"counterparty_name"`
+		CounterpartyType string `json:"counterparty_type"`
+		ProcessingStatus string `json:"processing_status"`
+		Category         string `json:"category"`
 	} `json:"details"`
+}
+
+// tellerAccountResponse represents an account from the Teller API response.
+type tellerAccountResponse struct {
+	ID           string `json:"id"`
+	EnrollmentID string `json:"enrollment_id"`
+	Name         string `json:"name"`
+	Type         string `json:"type"`
+	Subtype      string `json:"subtype"`
+	Status       string `json:"status"`
+	Currency     string `json:"currency"`
+	LastFour     string `json:"last_four"`
+	Institution  struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"institution"`
 }
 
 func (t *TellerAdapter) getClient() (*http.Client, error) {
@@ -86,9 +110,24 @@ func (t *TellerAdapter) ListAccounts(ctx context.Context, accessToken string) ([
 		return nil, fmt.Errorf("teller API error listing accounts: %d", resp.StatusCode)
 	}
 
-	var accounts []model.TellerAccount
-	if err := json.NewDecoder(resp.Body).Decode(&accounts); err != nil {
+	var raw []tellerAccountResponse
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
 		return nil, err
+	}
+	accounts := make([]model.TellerAccount, len(raw))
+	for i, r := range raw {
+		accounts[i] = model.TellerAccount{
+			ID:              r.ID,
+			EnrollmentID:    r.EnrollmentID,
+			Name:            r.Name,
+			Type:            r.Type,
+			Subtype:         r.Subtype,
+			Status:          r.Status,
+			Currency:        r.Currency,
+			LastFour:        r.LastFour,
+			InstitutionID:   r.Institution.ID,
+			InstitutionName: r.Institution.Name,
+		}
 	}
 	return accounts, nil
 }
@@ -133,8 +172,11 @@ func (t *TellerAdapter) FetchTransactions(ctx context.Context, accessToken strin
 	now := time.Now().UTC().Format(time.RFC3339)
 	for _, tt := range tellerTxns {
 		merchant := ""
+		var providerCategory, counterpartyType string
 		if tt.Details != nil {
 			merchant = tt.Details.CounterpartyName
+			providerCategory = tt.Details.Category
+			counterpartyType = tt.Details.CounterpartyType
 		}
 		date := tt.Date
 		if len(date) > 10 {
@@ -147,22 +189,33 @@ func (t *TellerAdapter) FetchTransactions(ctx context.Context, accessToken strin
 		if len(date) >= 4 {
 			year = date[:4]
 		}
+
+		amount, _ := strconv.ParseFloat(tt.Amount, 64)
+
+		rawPayload, _ := json.Marshal(tt)
+
 		pk := "TXN#teller#" + tt.ID
 		txn := model.Transaction{
-			PK:            pk,
-			Date:          date,
-			Source:        "teller",
-			Amount:        tt.Amount,
-			Currency:      tt.Currency,
-			Description:   tt.Description,
-			Merchant:      merchant,
-			IsConfirmed:   false,
-			PaymentMethod: "card",
-			RawPayload:    "",
-			CreatedAt:     now,
-			UpdatedAt:     now,
-			GSI1PK:        "YEAR#" + year,
-			GSI2PK:        "UNCONFIRMED",
+			PK:               pk,
+			Date:             date,
+			Source:           "teller",
+			Amount:           amount,
+			Currency:         tt.Currency,
+			Description:      tt.Description,
+			Merchant:         merchant,
+			TransactionType:  tt.Type,
+			ProviderCategory: providerCategory,
+			CounterpartyType: counterpartyType,
+			RunningBalance:   tt.RunningBalance,
+			AccountID:        tt.AccountID,
+			IsConfirmed:      false,
+			Pending:          tt.Status == "pending",
+			PaymentMethod:    "card",
+			RawPayload:       string(rawPayload),
+			CreatedAt:        now,
+			UpdatedAt:        now,
+			GSI1PK:           "YEAR#" + year,
+			GSI2PK:           "UNCONFIRMED",
 		}
 		txns = append(txns, txn)
 	}

--- a/backend/internal/repository/connection.go
+++ b/backend/internal/repository/connection.go
@@ -124,6 +124,39 @@ func connectionToItem(c *model.ProviderConnection) map[string]types.AttributeVal
 	if c.LastSyncedAt != nil {
 		item["lastSyncedAt"] = &types.AttributeValueMemberS{Value: *c.LastSyncedAt}
 	}
+	if c.AccountName != "" {
+		item["accountName"] = &types.AttributeValueMemberS{Value: c.AccountName}
+	}
+	if c.AccountType != "" {
+		item["accountType"] = &types.AttributeValueMemberS{Value: c.AccountType}
+	}
+	if c.AccountSubtype != "" {
+		item["accountSubtype"] = &types.AttributeValueMemberS{Value: c.AccountSubtype}
+	}
+	if c.InstitutionName != "" {
+		item["institutionName"] = &types.AttributeValueMemberS{Value: c.InstitutionName}
+	}
+	if c.InstitutionID != "" {
+		item["institutionId"] = &types.AttributeValueMemberS{Value: c.InstitutionID}
+	}
+	if c.Currency != "" {
+		item["currency"] = &types.AttributeValueMemberS{Value: c.Currency}
+	}
+	if c.LastFour != "" {
+		item["lastFour"] = &types.AttributeValueMemberS{Value: c.LastFour}
+	}
+	if c.Balance != nil {
+		item["balance"] = &types.AttributeValueMemberS{Value: *c.Balance}
+	}
+	if c.AvailableBalance != nil {
+		item["availableBalance"] = &types.AttributeValueMemberS{Value: *c.AvailableBalance}
+	}
+	if c.BalanceUpdatedAt != nil {
+		item["balanceUpdatedAt"] = &types.AttributeValueMemberS{Value: *c.BalanceUpdatedAt}
+	}
+	if c.Status != "" {
+		item["status"] = &types.AttributeValueMemberS{Value: c.Status}
+	}
 	return item
 }
 
@@ -152,6 +185,61 @@ func itemToConnection(item map[string]types.AttributeValue) (*model.ProviderConn
 	if v, ok := item["lastSyncedAt"]; ok {
 		if s, ok := v.(*types.AttributeValueMemberS); ok {
 			c.LastSyncedAt = &s.Value
+		}
+	}
+	if v, ok := item["accountName"]; ok {
+		if s, ok := v.(*types.AttributeValueMemberS); ok {
+			c.AccountName = s.Value
+		}
+	}
+	if v, ok := item["accountType"]; ok {
+		if s, ok := v.(*types.AttributeValueMemberS); ok {
+			c.AccountType = s.Value
+		}
+	}
+	if v, ok := item["accountSubtype"]; ok {
+		if s, ok := v.(*types.AttributeValueMemberS); ok {
+			c.AccountSubtype = s.Value
+		}
+	}
+	if v, ok := item["institutionName"]; ok {
+		if s, ok := v.(*types.AttributeValueMemberS); ok {
+			c.InstitutionName = s.Value
+		}
+	}
+	if v, ok := item["institutionId"]; ok {
+		if s, ok := v.(*types.AttributeValueMemberS); ok {
+			c.InstitutionID = s.Value
+		}
+	}
+	if v, ok := item["currency"]; ok {
+		if s, ok := v.(*types.AttributeValueMemberS); ok {
+			c.Currency = s.Value
+		}
+	}
+	if v, ok := item["lastFour"]; ok {
+		if s, ok := v.(*types.AttributeValueMemberS); ok {
+			c.LastFour = s.Value
+		}
+	}
+	if v, ok := item["balance"]; ok {
+		if s, ok := v.(*types.AttributeValueMemberS); ok {
+			c.Balance = &s.Value
+		}
+	}
+	if v, ok := item["availableBalance"]; ok {
+		if s, ok := v.(*types.AttributeValueMemberS); ok {
+			c.AvailableBalance = &s.Value
+		}
+	}
+	if v, ok := item["balanceUpdatedAt"]; ok {
+		if s, ok := v.(*types.AttributeValueMemberS); ok {
+			c.BalanceUpdatedAt = &s.Value
+		}
+	}
+	if v, ok := item["status"]; ok {
+		if s, ok := v.(*types.AttributeValueMemberS); ok {
+			c.Status = s.Value
 		}
 	}
 	return c, nil

--- a/backend/internal/repository/transaction.go
+++ b/backend/internal/repository/transaction.go
@@ -248,6 +248,30 @@ func transactionToItem(t *model.Transaction) map[string]types.AttributeValue {
 	if t.AccountName != "" {
 		item["accountName"] = &types.AttributeValueMemberS{Value: t.AccountName}
 	}
+	if t.Payee != "" {
+		item["payee"] = &types.AttributeValueMemberS{Value: t.Payee}
+	}
+	if t.Memo != "" {
+		item["memo"] = &types.AttributeValueMemberS{Value: t.Memo}
+	}
+	if t.TransactionType != "" {
+		item["transactionType"] = &types.AttributeValueMemberS{Value: t.TransactionType}
+	}
+	if t.ProviderCategory != "" {
+		item["providerCategory"] = &types.AttributeValueMemberS{Value: t.ProviderCategory}
+	}
+	if t.CounterpartyType != "" {
+		item["counterpartyType"] = &types.AttributeValueMemberS{Value: t.CounterpartyType}
+	}
+	if t.RunningBalance != nil {
+		item["runningBalance"] = &types.AttributeValueMemberS{Value: *t.RunningBalance}
+	}
+	if t.InstitutionName != "" {
+		item["institutionName"] = &types.AttributeValueMemberS{Value: t.InstitutionName}
+	}
+	if t.InstitutionID != "" {
+		item["institutionId"] = &types.AttributeValueMemberS{Value: t.InstitutionID}
+	}
 	if t.GSI2PK != "" {
 		item["gsi2pk"] = &types.AttributeValueMemberS{Value: t.GSI2PK}
 	}
@@ -331,6 +355,46 @@ func itemToTransaction(item map[string]types.AttributeValue) (*model.Transaction
 	if v, ok := item["accountName"]; ok {
 		if s, ok := v.(*types.AttributeValueMemberS); ok {
 			t.AccountName = s.Value
+		}
+	}
+	if v, ok := item["payee"]; ok {
+		if s, ok := v.(*types.AttributeValueMemberS); ok {
+			t.Payee = s.Value
+		}
+	}
+	if v, ok := item["memo"]; ok {
+		if s, ok := v.(*types.AttributeValueMemberS); ok {
+			t.Memo = s.Value
+		}
+	}
+	if v, ok := item["transactionType"]; ok {
+		if s, ok := v.(*types.AttributeValueMemberS); ok {
+			t.TransactionType = s.Value
+		}
+	}
+	if v, ok := item["providerCategory"]; ok {
+		if s, ok := v.(*types.AttributeValueMemberS); ok {
+			t.ProviderCategory = s.Value
+		}
+	}
+	if v, ok := item["counterpartyType"]; ok {
+		if s, ok := v.(*types.AttributeValueMemberS); ok {
+			t.CounterpartyType = s.Value
+		}
+	}
+	if v, ok := item["runningBalance"]; ok {
+		if s, ok := v.(*types.AttributeValueMemberS); ok {
+			t.RunningBalance = &s.Value
+		}
+	}
+	if v, ok := item["institutionName"]; ok {
+		if s, ok := v.(*types.AttributeValueMemberS); ok {
+			t.InstitutionName = s.Value
+		}
+	}
+	if v, ok := item["institutionId"]; ok {
+		if s, ok := v.(*types.AttributeValueMemberS); ok {
+			t.InstitutionID = s.Value
 		}
 	}
 	if v, ok := item["rawPayload"]; ok {

--- a/docs/API.md
+++ b/docs/API.md
@@ -138,19 +138,47 @@ List transactions with optional filters.
 ```json
 [
   {
-    "id": "TXN#manual#uuid-1234",
+    "id": "TXN#simplefin#acct-1#txn-5678",
     "date": "2026-02-15",
-    "source": "manual",
+    "source": "simplefin",
     "amount": 42.50,
     "currency": "USD",
-    "description": "Whole Foods Market",
-    "merchant": "Whole Foods",
+    "description": "WHOLE FOODS MKT #10234",
+    "merchant": "Whole Foods Market",
+    "payee": "Whole Foods Market",
+    "memo": "WHOLE FOODS MKT #10234 AUSTIN TX",
+    "institutionName": "Chase",
+    "institutionId": "chase-bank",
     "categoryId": "CAT#a1b2c3d4",
     "suggestedCategoryId": null,
     "isConfirmed": true,
-    "paymentMethod": "credit_card",
+    "pending": false,
+    "paymentMethod": "card",
+    "accountId": "acct-1",
+    "accountName": "Chase Checking",
     "createdAt": "2026-02-15T10:30:00Z",
     "updatedAt": "2026-02-15T10:30:00Z"
+  },
+  {
+    "id": "TXN#teller#txn-9012",
+    "date": "2026-02-14",
+    "source": "teller",
+    "amount": -15.99,
+    "currency": "USD",
+    "description": "Netflix",
+    "merchant": "Netflix",
+    "transactionType": "card_payment",
+    "providerCategory": "entertainment",
+    "counterpartyType": "organization",
+    "runningBalance": "1234.56",
+    "categoryId": null,
+    "suggestedCategoryId": null,
+    "isConfirmed": false,
+    "pending": false,
+    "paymentMethod": "card",
+    "accountId": "acc-12345",
+    "createdAt": "2026-02-14T06:00:00Z",
+    "updatedAt": "2026-02-14T06:00:00Z"
   }
 ]
 ```
@@ -371,7 +399,18 @@ List all bank provider connections.
   {
     "id": "CONN#teller#acc-12345",
     "provider": "teller",
-    "lastSyncedAt": "2026-02-15T06:00:00Z"
+    "lastSyncedAt": "2026-02-15T06:00:00Z",
+    "accountName": "Chase Checking",
+    "accountType": "depository",
+    "accountSubtype": "checking",
+    "institutionName": "Chase",
+    "institutionId": "chase",
+    "currency": "USD",
+    "lastFour": "4567",
+    "balance": "5432.10",
+    "availableBalance": "5200.00",
+    "balanceUpdatedAt": "2026-02-15T06:00:00Z",
+    "status": "open"
   }
 ]
 ```
@@ -436,15 +475,27 @@ The frontend defines these interfaces for API responses in `types/index.ts`:
 interface Transaction {
   id: string;
   date: string;
+  transactedAt?: string;
   source: string;
   amount: number;
   currency: string;
   description: string;
   merchant: string;
+  payee?: string;
+  memo?: string;
+  transactionType?: string;
+  providerCategory?: string;
+  counterpartyType?: string;
+  runningBalance?: string | null;
+  institutionName?: string;
+  institutionId?: string;
   categoryId: string | null;
   suggestedCategoryId: string | null;
   isConfirmed: boolean;
+  pending?: boolean;
   paymentMethod: string;
+  accountId?: string;
+  accountName?: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -475,6 +526,17 @@ interface Connection {
   id: string;
   provider: string;
   lastSyncedAt: string;
+  accountName?: string;
+  accountType?: string;
+  accountSubtype?: string;
+  institutionName?: string;
+  institutionId?: string;
+  currency?: string;
+  lastFour?: string;
+  balance?: string | null;
+  availableBalance?: string | null;
+  balanceUpdatedAt?: string | null;
+  status?: string;
 }
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -58,10 +58,10 @@ Expense Tally v2 is a full-stack serverless application hosted entirely on AWS. 
                          ▲
                          │
               ┌────────────────────┐          ┌──────────────────────┐
-              │  Sync Lambda       │─────────▶│  Teller API          │
-              │                    │          │  (Bank Provider)     │
-              │  EventBridge       │          └──────────────────────┘
-              │  rate(1 day)       │
+              │  Sync Lambda       │─────────▶│  SimpleFIN Bridge    │
+              │                    │          │  Teller API          │
+              │  EventBridge       │          │  (Bank Providers)    │
+              │  rate(1 day)       │          └──────────────────────┘
               └────────────────────┘
 ```
 
@@ -78,7 +78,7 @@ Expense Tally v2 is a full-stack serverless application hosted entirely on AWS. 
 | **Database** | Amazon DynamoDB (5 tables) | Primary data store, on-demand billing |
 | **Authentication** | Amazon Cognito | User management, OAuth 2.0 code flow, JWT tokens |
 | **Scheduler** | Amazon EventBridge | Daily sync trigger (rate 1 day) |
-| **Bank Integration** | Teller API | Financial transaction data provider |
+| **Bank Integration** | SimpleFIN Bridge, Teller API | Financial transaction data providers (see [ADR-001](adr/001-enrich-api-data-capture.md)) |
 | **Infrastructure** | AWS SAM (CloudFormation) | Infrastructure as code |
 | **CI/CD** | GitHub Actions | Automated build, test, and deploy |
 
@@ -153,6 +153,10 @@ Each entity gets its own table but uses composite key patterns for efficient que
 | Auth | Cognito Hosted UI | Managed OAuth 2.0 without custom auth UI |
 | IaC | AWS SAM | CloudFormation-based, first-class Lambda support |
 | CI/CD | GitHub Actions | Tightly integrated with source control |
+
+## Architecture Decision Records
+
+- [ADR-001: Enrich Database to Capture Full Provider API Data](adr/001-enrich-api-data-capture.md)
 
 ## Related Documentation
 

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -47,6 +47,7 @@ backend/
 │   │   └── time.go              # Time formatting utilities
 │   └── provider/                 # External provider adapters
 │       ├── adapter.go           # ProviderAdapter interface + factory
+│       ├── simplefin.go         # SimpleFIN Bridge implementation
 │       └── teller.go            # Teller API implementation
 ├── go.mod
 ├── go.sum
@@ -161,11 +162,13 @@ The Chi router applies the following middleware in order:
 
 | Model | Key Pattern | Description |
 |-------|-------------|-------------|
-| `Transaction` | `TXN#{source}#{id}` | Financial transaction with category, confirmation status |
+| `Transaction` | `TXN#{source}#{id}` | Financial transaction with category, confirmation status, provider-enriched metadata |
 | `Category` | `CAT#{uuid}` | Expense category with optional parent (hierarchy) |
 | `KeywordAssociation` | `KW#{keyword}` + `categoryId` | Keyword-to-category mapping with frequency |
-| `ProviderConnection` | `CONN#{provider}#{accountId}` | Bank connection with sync cursor |
+| `ProviderConnection` | `CONN#{provider}#{accountId}` | Bank connection with sync cursor, account metadata, balances |
 | `SyncLog` | `SYNC#{source}` + `{timestamp}` | Sync operation audit log |
+| `SimpleFINAccount` | (in-memory) | Account data from SimpleFIN including balances and org metadata |
+| `TellerAccount` | (in-memory) | Account data from Teller including type, subtype, institution, last four |
 
 ### Request/Response DTOs
 
@@ -214,8 +217,27 @@ type ProviderAdapter interface {
 ```
 
 - **Factory function**: `NewProviderAdapter(provider string)` returns the appropriate adapter
-- **Current adapters**: Teller (`teller.go`)
+- **Current adapters**: SimpleFIN (`simplefin.go`), Teller (`teller.go`)
 - **Extensibility**: Add new providers by implementing the interface and registering in the factory
+
+### Data Mapping
+
+Each adapter maps provider-specific API fields to the unified `model.Transaction`:
+
+| Transaction Field | SimpleFIN Source | Teller Source |
+|-------------------|------------------|---------------|
+| `Merchant` | `payee` (fallback: `org.name`) | `details.counterparty_name` |
+| `Payee` | `payee` | -- |
+| `Memo` | `memo` | -- |
+| `TransactionType` | -- | `type` (card_payment, ach, atm, etc.) |
+| `ProviderCategory` | -- | `details.category` |
+| `CounterpartyType` | -- | `details.counterparty.type` |
+| `RunningBalance` | -- | `running_balance` |
+| `InstitutionName` | `org.name` | -- |
+| `InstitutionID` | `org.id` | -- |
+| `RawPayload` | Full JSON | Full JSON |
+
+See [ADR-001](adr/001-enrich-api-data-capture.md) for the rationale behind the data capture decisions.
 
 ## Error Handling
 

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -243,10 +243,15 @@ Types:
 ### Adding a New Bank Provider
 
 1. Implement `ProviderAdapter` interface in `provider/newprovider.go`
-2. Register in `NewProviderAdapter()` factory function in `adapter.go`
-3. Create connection handler in `connections.go` (e.g., `CreateNewProvider`)
-4. Add route in `router.go`
-5. Frontend: Add connection creation UI
+2. Define provider-specific API response structs in the adapter file (see `simplefin.go` or `teller.go` for examples)
+3. Map all useful API fields to `model.Transaction` -- populate provider-specific fields like `TransactionType`, `ProviderCategory`, etc. where available, and always serialize the full API response as `RawPayload`
+4. If the provider has account-level data, add a corresponding model struct (e.g., `model.TellerAccount`) and populate enriched `ProviderConnection` fields
+5. Register in `NewAdapterFactory()` factory function in `adapter.go`
+6. Create connection handler in `connections.go` (e.g., `CreateNewProvider`)
+7. Add route in `router.go`
+8. Frontend: Add connection creation UI
+
+See [ADR-001](adr/001-enrich-api-data-capture.md) for the field mapping conventions used by existing providers.
 
 ### Adding a New DynamoDB Table
 

--- a/docs/adr/001-enrich-api-data-capture.md
+++ b/docs/adr/001-enrich-api-data-capture.md
@@ -1,0 +1,76 @@
+# ADR-001: Enrich Database to Capture Full Provider API Data
+
+**Date**: 2026-02-19
+
+**Status**: Accepted
+
+## Context
+
+Expense Tally integrates with two financial data providers -- SimpleFIN and Teller -- to sync bank transactions. The original implementation captured only a minimal subset of the data returned by each provider's API:
+
+- **SimpleFIN**: The `payee` field (clean merchant name) and `memo` field (raw bank memo) were ignored. The `merchant` field on transactions was populated with the institution's `org.name` rather than the actual payee. Account-level fields like `balance`, `available-balance`, and additional org metadata (`url`, `id`) were also dropped.
+
+- **Teller**: Transaction fields including `type` (card_payment, ach, atm, etc.), `status` (pending/posted as a string), `running_balance`, `details.category`, and `details.counterparty.type` were not captured. The `rawPayload` was stored as an empty string. Account metadata like `type`, `subtype`, `status`, `last_four`, and `institution` were not mapped to the domain model. The `TellerAccount` struct referenced in the adapter did not exist in the model package.
+
+This data loss made it harder to build features like smart categorization (which benefits from provider-assigned categories), merchant name disambiguation (payee vs. institution), and account detail display in the UI.
+
+## Decision
+
+Enrich the domain models, provider adapters, and repository layer to capture the full set of useful fields from both provider APIs. Specifically:
+
+### Transaction enrichment
+
+Add fields to `model.Transaction` that are meaningful across providers:
+
+| Field | Source: SimpleFIN | Source: Teller |
+|-------|-------------------|----------------|
+| `Payee` | `payee` (clean merchant name) | -- |
+| `Memo` | `memo` (raw bank memo) | -- |
+| `TransactionType` | -- | `type` (card_payment, ach, atm, credit, transfer) |
+| `ProviderCategory` | -- | `details.category` (dining, shopping, etc.) |
+| `CounterpartyType` | -- | `details.counterparty.type` (organization, person) |
+| `RunningBalance` | -- | `running_balance` (nullable) |
+| `InstitutionName` | `org.name` | -- |
+| `InstitutionID` | `org.id` | -- |
+
+The `Merchant` field semantics change: it is now set from the payee/counterparty name (the actual merchant), falling back to institution name only when payee is unavailable.
+
+### Account/connection enrichment
+
+Add fields to `model.ProviderConnection` for account metadata common across providers:
+
+`AccountName`, `AccountType`, `AccountSubtype`, `InstitutionName`, `InstitutionID`, `Currency`, `LastFour`, `Balance`, `AvailableBalance`, `BalanceUpdatedAt`, `Status`.
+
+Add `model.TellerAccount` struct (was referenced but missing) with full Teller account fields including institution metadata.
+
+Enrich `model.SimpleFINAccount` with balance and org metadata fields.
+
+### Provider adapter changes
+
+- **SimpleFIN**: Capture `payee`, `memo` from transactions; `url`, `id` from org; `available-balance` from accounts. Use `payee` as `Merchant` with fallback to `org.name`.
+- **Teller**: Parse `amount` as string (matching Teller's actual API format), capture `type`, `status`, `running_balance`, `details.category`, `details.counterparty.type`. Serialize full transaction JSON as `rawPayload`. Map `status: "pending"` to `Pending: true`.
+
+### What we chose NOT to capture
+
+- **Investment holdings** (SimpleFIN): A separate domain (investment tracking) with its own data model. Deferring to avoid scope creep.
+- **Account numbers / routing numbers** (Teller): Security-sensitive data from Teller's `/details` endpoint. Not needed for expense tracking and storing it would increase our security surface unnecessarily.
+
+## Consequences
+
+### Positive
+
+- **Better merchant identification**: Transactions now show the actual payee name instead of the institution name, improving readability and keyword-based auto-categorization accuracy.
+- **Provider category hints**: Teller's built-in category can bootstrap the auto-categorization system, especially for new users with no keyword history.
+- **Richer account display**: The UI can now show account type, last four digits, balance, and institution name on the connections page.
+- **Full audit trail**: `rawPayload` is now populated for Teller transactions (was empty), ensuring both providers have complete raw data for debugging.
+- **No schema migration required**: DynamoDB's schemaless nature means new attributes are written alongside existing ones without any table modification.
+
+### Negative
+
+- **Increased item size**: Each transaction and connection item stores more attributes in DynamoDB. For typical usage volumes this is negligible (items remain well under DynamoDB's 400KB limit).
+- **Teller amount type change**: `TellerTransaction.Amount` changed from `float64` to `string` to match Teller's actual API response, with parsing now done in the adapter's mapping logic. This is more correct but differs from the previous (implicit) behavior.
+
+### Neutral
+
+- **Backward compatible**: Existing transactions in DynamoDB are unaffected. The new fields use `omitempty` in JSON tags and conditional writes in the repository, so older items simply lack the new attributes and read back as zero values.
+- **Frontend impact**: The frontend TypeScript `Transaction` interface should be updated to expose the new fields, but existing fields remain unchanged so the UI will continue to work without frontend changes.

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -7,6 +7,14 @@ export interface Transaction {
   currency: string;
   description: string;
   merchant: string;
+  payee?: string;
+  memo?: string;
+  transactionType?: string;
+  providerCategory?: string;
+  counterpartyType?: string;
+  runningBalance?: string | null;
+  institutionName?: string;
+  institutionId?: string;
   categoryId: string | null;
   suggestedCategoryId: string | null;
   isConfirmed: boolean;
@@ -44,4 +52,15 @@ export interface Connection {
   id: string;
   provider: string;
   lastSyncedAt: string;
+  accountName?: string;
+  accountType?: string;
+  accountSubtype?: string;
+  institutionName?: string;
+  institutionId?: string;
+  currency?: string;
+  lastFour?: string;
+  balance?: string | null;
+  availableBalance?: string | null;
+  balanceUpdatedAt?: string | null;
+  status?: string;
 }


### PR DESCRIPTION
Add new fields to Transaction (payee, memo, transactionType, providerCategory, counterpartyType, runningBalance, institutionName, institutionID) and ProviderConnection (account metadata, balances, institution details).

Update SimpleFIN adapter to capture payee, memo, org details, and balance fields. Update Teller adapter to capture type, status, category, counterparty, running_balance, and serialize rawPayload. Update repository layer to persist all new fields. Add TellerAccount model and enrich SimpleFINAccount.

Update frontend TypeScript types, documentation, and add ADR-001.